### PR TITLE
[Feature] - exit and don't update .env if keyword missing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: -- --test-threads=1
 
   fmt:
     name: Rustfmt

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,13 @@ fn main() {
         process::exit(1);
     });
 
-    let new_env = parser::parse_env(&env, &config);
+    let new_env = match parser::parse_env(&env, &config) {
+        Ok(env) => env,
+        Err(e) => {
+            eprintln!("Problem parsing env: {}", e);
+            process::exit(1);
+        }
+    };
 
     match utils::write_to_file(&new_env) {
         Ok(_) => println!("Updated .env to {}", &config.keyword),


### PR DESCRIPTION
This is a feature requested by a user, when they misspelled their keyword the script silently just proceeded and uncommented out the other keywords.

Now we leave the .env as-is, and provide a nice error message to the user, e.g:
![image](https://user-images.githubusercontent.com/21317379/118034357-cb5cfa80-b361-11eb-9f97-3e94a495e665.png)