### PR TITLE
Cargo doc comments and some updates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+//! A library exposing modules to perform the business
+//! logic around changing env vars, and also some utility
+//! functions and data types.
+
 #[macro_use]
 extern crate lazy_static;
 pub mod parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
         }
     };
 
-    match utils::write_to_file(&new_env) {
+    match utils::write_env_file(&new_env) {
         Ok(_) => println!("Updated .env to {}", &config.keyword),
         Err(e) => {
             eprintln!("Problem reading .env file: {}", e);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -54,16 +54,7 @@ fn resolve_keyword(line: &str) -> Option<&str> {
 /// Core function which performs all parsing and returns results
 ///
 /// This function accepts and returns the structs available in the
-/// [utils](../utils/index.html) module:
-///
-/// # Examples
-///
-/// ```
-/// let config = utils::Config::new(env::args())?;
-/// let env = utils::read_env_file()?;
-///
-/// let new_env = parse_env(&env, &config)?;
-/// ```
+/// [utils](../utils/index.html) module.
 pub fn parse_env(env: &EnvContents, config: &Config) -> Result<EnvContents, String> {
     let lines = env.contents.lines();
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,8 +1,24 @@
-use crate::utils::{Config, EnvContents, ParseStatus};
+//! Functions containing the core business logic around parsing.
+//!
+//! All of these functions encapsulate the "what" of cenv,
+//! including:
+//!
+//! - What constitutes a "keyword"
+//! - Which lines within the .env file should be updated
+//! - The format that should be returned to the callee
+
+use crate::utils::{Config, EnvContents};
 use regex::Regex;
 
 lazy_static! {
     static ref KEYWORD_REGEX: Regex = Regex::new(r"^#+ *\+\+ *(\w+)").unwrap();
+}
+
+#[derive(PartialEq)]
+enum ParseStatus {
+    Active,
+    Inactive,
+    Ignore,
 }
 
 fn parse_as_active(line: &str) -> String {
@@ -35,6 +51,19 @@ fn resolve_keyword(line: &str) -> Option<&str> {
     Some(&keyword)
 }
 
+/// Core function which performs all parsing and returns results
+///
+/// This function accepts and returns the structs available in the
+/// [utils](../utils/index.html) module:
+///
+/// # Examples
+///
+/// ```
+/// let config = utils::Config::new(env::args())?;
+/// let env = utils::read_env_file()?;
+///
+/// let new_env = parse_env(&env, &config)?;
+/// ```
 pub fn parse_env(env: &EnvContents, config: &Config) -> Result<EnvContents, String> {
     let lines = env.contents.lines();
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,19 +1,22 @@
+//! Helper functions and data types
+//!
+//! This module provides business-logic agnostic helpers
+//! which can be used throughout the cenv codebase.
+//!
+//!
+
 use std::fs;
 use std::io::Write;
 
-#[derive(PartialEq)]
-pub enum ParseStatus {
-    Active,
-    Inactive,
-    Ignore,
-}
-
+/// Configuration of the current domain
 #[derive(PartialEq, Debug)]
 pub struct Config {
     pub keyword: String,
 }
 
 impl Config {
+    /// Accepts a list of arguments, usually an [Args][std::env::Args] struct
+    /// sourced from the [std::env::args] function.
     pub fn new<T>(mut args: T) -> Result<Config, &'static str>
     where
         T: Iterator<Item = String>,
@@ -30,6 +33,7 @@ impl Config {
     }
 }
 
+/// Details around the content to be parsed
 #[derive(PartialEq, Debug)]
 pub struct EnvContents {
     pub contents: String,
@@ -41,6 +45,7 @@ impl EnvContents {
     }
 }
 
+/// Reads .env file in execution scope
 pub fn read_env_file() -> Result<EnvContents, &'static str> {
     let contents = match fs::read_to_string(".env") {
         Ok(w) => w,
@@ -49,7 +54,8 @@ pub fn read_env_file() -> Result<EnvContents, &'static str> {
     Ok(EnvContents { contents })
 }
 
-pub fn write_to_file(env: &EnvContents) -> Result<(), String> {
+/// Writes to the .env file in execution scope
+pub fn write_env_file(env: &EnvContents) -> Result<(), String> {
     let mut file = match fs::File::create(".env") {
         Ok(f) => f,
         Err(e) => return Err(format!("Unable to write .env file - {}", e)),
@@ -119,7 +125,7 @@ TEST_A=3
 TEST_B=3
 ",
         );
-        write_to_file(&EnvContents::new(contents)).unwrap();
+        write_env_file(&EnvContents::new(contents)).unwrap();
     }
 
     #[test]
@@ -152,7 +158,7 @@ TEST_B=3
 }
 
 #[cfg(test)]
-mod write_to_file_tests {
+mod write_env_file_tests {
     use super::*;
 
     #[test]
@@ -171,7 +177,7 @@ TEST_A=3
 TEST_B=3
 ",
         );
-        let result = write_to_file(&EnvContents::new(contents));
+        let result = write_env_file(&EnvContents::new(contents));
         assert_eq!(result, Ok(()));
     }
 }


### PR DESCRIPTION
- Add cargo doc comments available via. `cargo doc --open`
- Changed `write_to_file` function name to `write_env_file`
- Moved `ParseStatus` out of utils, and into parser module