### PR TITLE
De-duplicate keywords listed after an invalid choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Target [rust 2021](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html#rust-2021)
 - Comments are now valid within "cenv" blocks and will be ignored
+- The keywords listed when an invalid choice is made are now de-deuplicated
 
 ## [1.1.0] - 2021-08-02
 ### Added

--- a/cenv_core/CHANGELOG.md
+++ b/cenv_core/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Target [rust 2021](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html#rust-2021)
 - Comments are now valid within "cenv" blocks and will be ignored by the parser
+- `list_available_keywords` now de-deuplicates listed keywords
 
 ## 0.2.0 - 2021-08-02
 ### Added


### PR DESCRIPTION
Including a keyword multiple times within a `.env` file is a valid pattern, but currently the list shown after an invalid selection shows every keyword with no logic. This change de-duplicates the keywords listed

## Example Source
```.env
# ++ one ++
TEST_A=1
# ++ two ++
# TEST_A=2
# ++ three ++
# TEST_A=3

# ++ one ++
TEST_B=1
# ++ two ++
# TEST_B=2
# ++ three ++
# TEST_B=3
```

## Current
User runs `cenv four`

Output:
```
Problem parsing env: keyword "four" was not found in .env file
Available keywords:
- one
- two
- three
- one
- two
- three
```

## New behaviour
User runs `cenv four`

Output:
```
Problem parsing env: keyword "four" was not found in .env file
Available keywords:
- three
- one
- two
```

Caveat of using HashMap to dedup is that the order is no longer stable, but there's generally no significance to the ordering of the keywords, so this is fine (and can be amended in future if really necessary)