### PR TITLE
Regex bump and release build optimisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Binary size reduced following optimisations from [min-sized-rust](https://github.com/johnthagen/min-sized-rust) guide
 
 ## [1.2.0] - 2021-12-21
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -51,6 +51,6 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [package]
 name = "cenv"
 version = "1.2.0"
@@ -6,7 +7,11 @@ edition = "2021"
 license = "MIT"
 repository = "https://github.com/JonShort/cenv"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[profile.release]
+codegen-units = 1 # Maximum size-reduction optimisations
+lto = true # Enable "link time optimisation"
+panic = "abort" # Remove lengthy stack traces
+strip = true  # Automatically strip symbols from the binary.
 
 [dependencies]
 cenv_core = { path = "./cenv_core" }

--- a/cenv_core/CHANGELOG.md
+++ b/cenv_core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- [regex](https://crates.io/crates/regex) crate dependency bumped to [1.5.6](https://github.com/rust-lang/regex/blob/master/CHANGELOG.md#156-2022-05-20)
 
 ## 0.3.0 - 2021-12-21
 ### Changed

--- a/cenv_core/Cargo.toml
+++ b/cenv_core/Cargo.toml
@@ -11,4 +11,4 @@ include = ["src/**/*", "LICENSE"]
 
 [dependencies]
 lazy_static = "1.4"
-regex = "1.5.4"
+regex = "1.5.6"


### PR DESCRIPTION
- [regex](https://crates.io/crates/regex) crate 1.5.4 -> 1.5.6 ([changelog](https://github.com/rust-lang/regex/blob/master/CHANGELOG.md))
- release build optimisations, locally binary is reduced 1.7mb -> 1.1mb
  - as seen https://github.com/johnthagen/min-sized-rust