### PR TITLE
Make regexes safer, but stricter (also allow dashes in keywords now)

### DIFF
--- a/cenv_core/CHANGELOG.md
+++ b/cenv_core/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- [BREAKING] Keyword line formatting is now stricter, e.g. `##++ thing` would previously match, now single comment & space are required, e.g. `# ++ thing`
+- [BREAKING] The env var regex now expects env var names to follow [the UNIX-style standard for environment variables](https://pubs.opengroup.org/onlinepubs/7908799/xbd/envvar.html#:~:text=Environment%20variable%20names%20used%20by,the%20presence%20of%20such%20names.), but allows the following `0-9`, `A-Z`, `a-z`, `_`
+- Keywords can now contain dashes
 
 ## 0.3.1 - 2023-01-15
 ### Changed

--- a/cenv_core/src/parser/mod.rs
+++ b/cenv_core/src/parser/mod.rs
@@ -12,8 +12,8 @@ use regex::Regex;
 use std::collections::HashMap;
 
 lazy_static! {
-    static ref KEYWORD_REGEX: Regex = Regex::new(r"^#+ *\+\+ *(\w+)").unwrap();
-    static ref VAR_REGEX: Regex = Regex::new(r"^# *(\S+=\S*)").unwrap();
+    static ref KEYWORD_REGEX: Regex = Regex::new(r"^# \+\+ ([0-9A-Za-z_-]{1,100})").unwrap();
+    static ref VAR_REGEX: Regex = Regex::new(r"^# ?([[:word:]]+=\S*)").unwrap();
 }
 
 #[derive(PartialEq)]
@@ -194,18 +194,31 @@ mod resolve_keyword_tests {
     }
 
     #[test]
+    fn none_if_invalid_formatted_variant_1() {
+        assert_eq!(resolve_keyword("#++ keyword"), None);
+    }
+
+    #[test]
+    fn none_if_invalid_formatted_variant_2() {
+        assert_eq!(resolve_keyword("## ++ keyword ++"), None);
+    }
+
+    #[test]
     fn word_if_formatted_variant_1() {
         assert_eq!(resolve_keyword("# ++ keyword ++"), Some("keyword"));
     }
 
     #[test]
     fn word_if_formatted_variant_2() {
-        assert_eq!(resolve_keyword("#++ keyword"), Some("keyword"));
+        assert_eq!(resolve_keyword("# ++ my-env ++"), Some("my-env"));
     }
 
     #[test]
     fn word_if_formatted_variant_3() {
-        assert_eq!(resolve_keyword("## ++ keyword ++"), Some("keyword"));
+        assert_eq!(
+            resolve_keyword("# ++ prod_environment ++"),
+            Some("prod_environment")
+        );
     }
 }
 

--- a/cenv_core/src/parser/mod.rs
+++ b/cenv_core/src/parser/mod.rs
@@ -132,8 +132,16 @@ mod parse_as_active_tests {
     }
 
     #[test]
-    fn removes_hash_from_var() {
+    fn removes_hash_from_var_variant_1() {
         assert_eq!(parse_as_active("# VAR=true"), "VAR=true");
+    }
+
+    #[test]
+    fn removes_hash_from_var_variant_2() {
+        assert_eq!(
+            parse_as_active("# TEST_VAR_ENTRY=some??weird__43££combo*~*😃*929100"),
+            "TEST_VAR_ENTRY=some??weird__43££combo*~*😃*929100"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Changed
- [BREAKING] Keyword line formatting is now stricter, e.g. `##++ thing` would previously match, now single comment & space are required, e.g. `# ++ thing`
- [BREAKING] The env var regex now expects env var names to follow [the UNIX-style standard for environment variables](https://pubs.opengroup.org/onlinepubs/7908799/xbd/envvar.html#:~:text=Environment%20variable%20names%20used%20by,the%20presence%20of%20such%20names.), but allows the following `0-9`, `A-Z`, `a-z`, `_`
- Keywords can now contain dashes