### PR TITLE
Bump regex crate to 1.10.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -34,15 +34,27 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -51,6 +63,6 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"

--- a/cenv_core/CHANGELOG.md
+++ b/cenv_core/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [BREAKING] Keyword line formatting is now stricter, e.g. `##++ thing` would previously match, now single comment & space are required, e.g. `# ++ thing`
 - [BREAKING] The env var regex now expects env var names to follow [the UNIX-style standard for environment variables](https://pubs.opengroup.org/onlinepubs/7908799/xbd/envvar.html#:~:text=Environment%20variable%20names%20used%20by,the%20presence%20of%20such%20names.), but allows the following `0-9`, `A-Z`, `a-z`, `_`
 - Keywords can now contain dashes
+- Updated the [regex](https://crates.io/crates/regex) dependency to 1.10.x
 
 ## 0.3.1 - 2023-01-15
 ### Changed

--- a/cenv_core/Cargo.toml
+++ b/cenv_core/Cargo.toml
@@ -11,4 +11,4 @@ include = ["src/**/*", "LICENSE"]
 
 [dependencies]
 lazy_static = "1.4"
-regex = "1.7"
+regex = "1.10"

--- a/cenv_core/src/parser/mod.rs
+++ b/cenv_core/src/parser/mod.rs
@@ -24,11 +24,10 @@ enum ParseStatus {
 }
 
 fn parse_as_active(line: &str) -> String {
-    if let Some(captures) = VAR_REGEX.captures(line) {
-        return String::from(captures.get(1).map_or("", |m| m.as_str()));
-    };
-
-    String::from(line)
+    match VAR_REGEX.captures(line).map(|caps| caps.extract()) {
+        Some((_, [var])) => String::from(var),
+        _ => String::from(line),
+    }
 }
 
 fn parse_as_inactive(line: &str) -> String {
@@ -46,11 +45,10 @@ fn parse_as_inactive(line: &str) -> String {
 /// This function accepts the EnvContents struct available in the
 /// [utils](../utils/index.html) module.
 pub fn resolve_keyword(line: &str) -> Option<&str> {
-    if let Some(captures) = KEYWORD_REGEX.captures(line) {
-        return Some(captures.get(1).map_or("", |m| m.as_str()));
-    };
-
-    None
+    match KEYWORD_REGEX.captures(line).map(|caps| caps.extract()) {
+        Some((_, [keyword])) => Some(keyword),
+        _ => None,
+    }
 }
 
 /// Supplementary function which returns a Vec of all keywords within the env


### PR DESCRIPTION
* Regex crate changelog - https://github.com/rust-lang/regex/blob/master/CHANGELOG.md
* Refactor existing code which incorporates regex captures to use the new `Captures::extract` method which [was introduced in regex 1.9.0](https://github.com/rust-lang/regex/blob/master/CHANGELOG.md#190-2023-07-05)